### PR TITLE
Strengthen provider config and verification checks

### DIFF
--- a/v1/genesis/agents/runtime.py
+++ b/v1/genesis/agents/runtime.py
@@ -9,6 +9,8 @@ from typing import Any, Optional
 
 import requests
 
+from genesis.config import load_api_config
+
 
 @dataclass
 class CategoryConfig:
@@ -20,7 +22,10 @@ class CategoryConfig:
 
 
 class ProviderRuntimeError(RuntimeError):
-    pass
+    def __init__(self, message: str, *, error_class: str = "provider_error", retryable: bool = True):
+        super().__init__(message)
+        self.error_class = error_class
+        self.retryable = retryable
 
 
 class CodingAgentRuntime:
@@ -34,6 +39,7 @@ class CodingAgentRuntime:
         self.config_path = Path(config_path)
         self.session = session or requests.Session()
         self.timeout = timeout
+        self.api_config = load_api_config()
         self.categories = self._load_categories()
 
     def generate_task(
@@ -47,6 +53,7 @@ class CodingAgentRuntime:
         category_config = self.categories[category]
         prompt = self._build_prompt(instruction, context, budget or {}, category)
         errors: list[str] = []
+        last_error = ProviderRuntimeError("no provider attempts executed")
         for model in [category_config.model] + list(category_config.fallbacks):
             try:
                 if category_config.provider == "ollama":
@@ -59,10 +66,21 @@ class CodingAgentRuntime:
                 payload["provider"] = category_config.provider
                 payload["model"] = model
                 payload["raw_response"] = content
+                payload["retryable"] = False
+                payload["error_class"] = None
                 return payload
-            except Exception as exc:  # noqa: BLE001
+            except ProviderRuntimeError as exc:
                 errors.append(f"{model}: {exc}")
-        raise ProviderRuntimeError("; ".join(errors))
+                last_error = exc
+            except Exception as exc:  # noqa: BLE001
+                generic = ProviderRuntimeError(str(exc), error_class="unexpected_runtime_error", retryable=False)
+                errors.append(f"{model}: {generic}")
+                last_error = generic
+        raise ProviderRuntimeError(
+            "; ".join(errors),
+            error_class=last_error.error_class if errors else "provider_error",
+            retryable=last_error.retryable if errors else True,
+        )
 
     def _load_categories(self) -> dict[str, CategoryConfig]:
         raw = self.config_path.read_text(encoding="utf-8")
@@ -96,48 +114,73 @@ class CodingAgentRuntime:
         )
 
     def _invoke_ollama(self, model: str, prompt: str, category: CategoryConfig) -> str:
-        base_url = os.getenv("OLLAMA_BASE_URL", "http://127.0.0.1:11434")
-        response = self.session.post(
-            f"{base_url.rstrip('/')}/api/chat",
-            json={
-                "model": model,
-                "messages": [{"role": "user", "content": prompt}],
-                "stream": False,
-                "options": {"temperature": category.temperature, "num_predict": category.max_tokens},
-            },
-            timeout=self.timeout,
-        )
-        response.raise_for_status()
-        payload = response.json()
-        return payload.get("message", {}).get("content", "")
+        base_url = self.api_config["ollama_base_url"]
+        try:
+            response = self.session.post(
+                f"{base_url.rstrip('/')}/api/chat",
+                json={
+                    "model": model,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "stream": False,
+                    "options": {"temperature": category.temperature, "num_predict": category.max_tokens},
+                },
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            return payload.get("message", {}).get("content", "")
+        except requests.RequestException as exc:
+            raise ProviderRuntimeError(
+                str(exc),
+                error_class="ollama_connection_error",
+                retryable=True,
+            ) from exc
 
     def _invoke_groq(self, model: str, prompt: str, category: CategoryConfig) -> str:
-        api_key = os.getenv("GROQ_API_KEY")
-        if not api_key:
-            raise ProviderRuntimeError("GROQ_API_KEY is not configured")
-        response = self.session.post(
-            "https://api.groq.com/openai/v1/chat/completions",
-            headers={"Authorization": f"Bearer {api_key}"},
-            json={
-                "model": model,
-                "temperature": category.temperature,
-                "max_tokens": category.max_tokens,
-                "messages": [{"role": "user", "content": prompt}],
-                "response_format": {"type": "json_object"},
-            },
-            timeout=self.timeout,
+        keys = self.api_config["groq_api_keys"]
+        if not keys:
+            raise ProviderRuntimeError(
+                "GROQ_API_KEY is not configured",
+                error_class="groq_credentials_missing",
+                retryable=False,
+            )
+        errors: list[str] = []
+        for api_key in keys:
+            try:
+                response = self.session.post(
+                    "https://api.groq.com/openai/v1/chat/completions",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                    json={
+                        "model": model,
+                        "temperature": category.temperature,
+                        "max_tokens": category.max_tokens,
+                        "messages": [{"role": "user", "content": prompt}],
+                        "response_format": {"type": "json_object"},
+                    },
+                    timeout=self.timeout,
+                )
+                response.raise_for_status()
+                payload = response.json()
+                return payload["choices"][0]["message"]["content"]
+            except requests.RequestException as exc:
+                errors.append(str(exc))
+        raise ProviderRuntimeError(
+            "; ".join(errors),
+            error_class="groq_request_failed",
+            retryable=True,
         )
-        response.raise_for_status()
-        payload = response.json()
-        return payload["choices"][0]["message"]["content"]
 
     def _parse_payload(self, content: str) -> dict[str, Any]:
         if not content:
-            raise ProviderRuntimeError("empty model response")
+            raise ProviderRuntimeError("empty model response", error_class="empty_response", retryable=True)
         try:
             return json.loads(content)
         except json.JSONDecodeError:
             match = re.search(r"\{.*\}", content, re.DOTALL)
             if match:
                 return json.loads(match.group(0))
-        raise ProviderRuntimeError("model response did not contain valid JSON")
+        raise ProviderRuntimeError(
+            "model response did not contain valid JSON",
+            error_class="invalid_json_response",
+            retryable=True,
+        )

--- a/v1/genesis/config.py
+++ b/v1/genesis/config.py
@@ -54,10 +54,20 @@ def load_project_config(path: Union[str, Path]) -> ProjectConfig:
 
 def load_api_config() -> dict[str, Any]:
     semantic_scholar_key = os.getenv("SEMANTIC_SCHOLAR_API_KEY")
-    groq_keys = [value for key, value in sorted(os.environ.items()) if key.startswith("GROQ_API_KEY")]
-    ollama_keys = [value for key, value in sorted(os.environ.items()) if key.startswith("OLLAMA_API_KEY")]
+    groq_keys = [
+        value
+        for key, value in sorted(os.environ.items())
+        if key.startswith("GROQ_API_KEY") and value
+    ]
+    ollama_keys = [
+        value
+        for key, value in sorted(os.environ.items())
+        if key.startswith("OLLAMA_API_KEY") and value
+    ]
+    ollama_base_url = os.getenv("OLLAMA_BASE_URL", "http://127.0.0.1:11434")
     return {
         "semantic_scholar_api_key": semantic_scholar_key,
         "groq_api_keys": groq_keys,
         "ollama_api_keys": ollama_keys,
+        "ollama_base_url": ollama_base_url,
     }

--- a/v1/genesis/modules/verification/pipeline.py
+++ b/v1/genesis/modules/verification/pipeline.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Optional, Union
 
+from genesis.modules.citations.agent import CitationsAgent
 from genesis.modules.adversarial.formal import FormalConsistencyChecker
 from genesis.modules.oracle.validator import OracleValidator
 
@@ -26,13 +27,50 @@ class VerificationPipeline:
         }
         results_file = outputs_dir / "result.json"
         if results_file.exists():
+            result_payload = self._load_result(results_file)
             report["checks"].append({"name": "artifact_exists", "passed": True})
             report["checks"].append(
                 self.formal.check_implementation_drift(results_file.read_text(encoding="utf-8"), results_file).to_dict()
             )
+            report["checks"].append(self._metric_consistency_check(result_payload))
         else:
             report["checks"].append({"name": "artifact_exists", "passed": False})
         if oracle_path:
             report["checks"].append(self.oracle_validator.run_oracle(oracle_path, outputs_dir).to_dict())
+        citation_flags = self._citation_check(outputs_dir)
+        if citation_flags:
+            report["checks"].append({"name": "citation_verification", "passed": False, "flags": citation_flags})
+        else:
+            report["checks"].append({"name": "citation_verification", "passed": True})
         report["passed"] = all(check.get("passed", True) or check.get("pass_rate", 0.0) > 0.0 for check in report["checks"])
         return report
+
+    def _load_result(self, path: Path) -> dict[str, Any]:
+        import json
+
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def _metric_consistency_check(self, payload: dict[str, Any]) -> dict[str, Any]:
+        selected = payload.get("selected_experiment")
+        if not isinstance(selected, dict):
+            return {"name": "metric_consistency", "passed": True}
+        primary_metric = float(payload.get("primary_metric", 0.0))
+        selected_metric = float(selected.get("primary_metric", primary_metric))
+        passed = abs(primary_metric - selected_metric) < 1e-6
+        return {
+            "name": "metric_consistency",
+            "passed": passed,
+            "evidence": [f"primary_metric={primary_metric}", f"selected_metric={selected_metric}"],
+        }
+
+    def _citation_check(self, outputs_dir: Path) -> list[dict[str, Any]]:
+        paper_dir = outputs_dir.parent / "paper"
+        tex_path = paper_dir / "main.tex"
+        bib_path = paper_dir / "references.bib"
+        if not tex_path.exists() or not bib_path.exists():
+            return []
+        agent = CitationsAgent(outputs_dir.parent.parent / "knowledge" / "citations_cache.json")
+        return agent.verify_all_in_latex(
+            tex_path.read_text(encoding="utf-8"),
+            bib_path.read_text(encoding="utf-8"),
+        )


### PR DESCRIPTION
Harden the production runtime by improving provider credential/fallback handling and extending verification beyond file presence so the branch keeps moving from a runnable prototype toward guide-level operational correctness.

Constraint: Keep the changes isolated to v1-only paths on the active integration branch
Rejected: Leave provider selection and verification as thin wrappers | that would keep the runtime too brittle for production expectations
Confidence: medium
Scope-risk: narrow
Reversibility: clean
Directive: Continue replacing shallow integrations with explicit operational behavior and evidence-rich verification
Tested: python3 -m pytest tests/unit tests/integration tests/benchmarks -q; python3 -m genesis.cli.main build-manifold --domain astrophysics; python3 -m genesis.cli.main init-taste
Not-tested: Live Groq key rotation, live remote provider retries, and full production network-failure behavior